### PR TITLE
recipient_thread_close via Buttons

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -49,12 +49,14 @@ class ConfigManager:
         # threads
         "sent_emoji": "\N{WHITE HEAVY CHECK MARK}",
         "blocked_emoji": "\N{NO ENTRY SIGN}",
-        "close_emoji": "\N{LOCK}",
+        "close_emoji": None,
         "use_user_id_channel_name": False,
         "use_timestamp_channel_name": False,
         "use_nickname_channel_name": False,
         "use_random_channel_name": False,
         "recipient_thread_close": False,
+        "recipient_thread_close_button_label": None,
+        "recipient_thread_close_button_style": "red",
         "thread_show_roles": True,
         "thread_show_account_age": True,
         "thread_show_join_age": True,
@@ -65,7 +67,7 @@ class ConfigManager:
         "thread_creation_response": "The staff team will get back to you as soon as possible.",
         "thread_creation_footer": "Your message has been sent",
         "thread_contact_silently": False,
-        "thread_self_closable_creation_footer": "Click the lock to close the thread",
+        "thread_self_closable_creation_footer": "Click the button to close the thread",
         "thread_creation_contact_title": "New Thread",
         "thread_creation_self_contact_response": "You have opened a Modmail thread.",
         "thread_creation_contact_response": "{creator.name} has opened a Modmail thread.",
@@ -233,7 +235,8 @@ class ConfigManager:
     enums = {
         "dm_disabled": DMDisabled,
         "status": discord.Status,
-        "activity_type": discord.ActivityType,
+        "activity_type": discord.ActivityType
+        #"recipient_thread_close_button_style": discord.ButtonStyle
     }
 
     force_str = {"command_permissions", "level_permissions"}

--- a/core/config.py
+++ b/core/config.py
@@ -232,12 +232,7 @@ class ConfigManager:
         "registry_plugins_only",
     }
 
-    enums = {
-        "dm_disabled": DMDisabled,
-        "status": discord.Status,
-        "activity_type": discord.ActivityType
-        #"recipient_thread_close_button_style": discord.ButtonStyle
-    }
+    enums = {"dm_disabled": DMDisabled, "status": discord.Status, "activity_type": discord.ActivityType}
 
     force_str = {"command_permissions", "level_permissions"}
 

--- a/core/config_help.json
+++ b/core/config_help.json
@@ -285,8 +285,8 @@
     ]
   },
   "close_emoji": {
-    "default": "🔒",
-    "description": "This is the emoji the recipient can click to close a thread themselves. The emoji is automatically added to the `thread_creation_response` embed.",
+    "default": "None",
+    "description": "This is the emoji for the close button the recipient can click to close a thread themselves. The emoji (attached to the button) is automatically added to the `thread_creation_response` embed.",
     "examples": [
       "`{prefix}config set close_emoji 👍‍`"
     ],
@@ -297,14 +297,37 @@
   },
   "recipient_thread_close": {
     "default": "Disabled",
-    "description": "Setting this configuration will allow recipients to use the `close_emoji` to close the thread themselves.",
+    "description": "Setting this configuration will allow recipients to close threads by themselves via a button.",
     "examples": [
       "`{prefix}config set recipient_thread_close yes`",
       "`{prefix}config set recipient_thread_close no`"
     ],
     "notes": [
-      "The close emoji is dictated by the configuration `close_emoji`.",
-      "See also: `close_emoji`."
+      "The button attached to the `thread_creation_response` can have set a custom label, emoji or even both.",
+      "See also: `close_emoji`, `recipient_thread_close_button_label`, `recipient_thread_close_button_style`."
+    ]
+  },
+  "recipient_thread_close_button_label": {
+    "default": "None",
+    "description": "This configuration changes the label of the button for the `recipient_thread_close` feature.",
+    "examples": [
+      "`{prefix}config set recipient_thread_close_button_label Your label`"
+    ],
+    "notes": [
+      "The label cannot exceed 80 characters.",
+      "See also: `recipient_thread_close`, `close_emoji`, `recipient_thread_close_button_style`."
+    ]
+  },
+  "recipient_thread_close_button_style": {
+    "default": "red",
+    "description": "This configuration changes the style of the button for the `recipient_thread_close` feature.",
+    "examples": [
+      "`{prefix}config set recipient_thread_close_button_style green`",
+      "`{prefix}config set recipient_thread_close_button_style blurple`"
+    ],
+    "notes": [
+      "The style is limited by discord to the following colors: blurple, green, red, gray.",
+      "See also: `recipient_thread_close`, `close_emoji`, `recipient_thread_close_button_label`."
     ]
   },
   "thread_show_roles": {


### PR DESCRIPTION
- Updates the recipient_thread_close feature to use a button instead of a reaction.
- New config options: recipient_thread_close_button_label, recipient_thread_close_button_style
- The close_emoji default value is now None to make it possible changing the button to only have a label.